### PR TITLE
Add AI skill design guides, starter SKILLs, and authoring templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # solidJSkills
-A repo intended to be an mcp server for SolidJS Agentic Skills
+
+A practical repository for **AI skill design concepts**, **agentic workflow engineering**, and reusable templates for building robust `SKILL.md`-based skill systems.
+
+## What this repo contains
+
+- `guides/` — semantic guides for designing skills, tools, workflows, rules, and system prompts.
+- `skills/` — starter skills that show clear directory structure and instruction quality.
+- `tools/templates/` — reusable templates you can copy when authoring new skill components.
+
+## Design goals
+
+1. Standardize how AI skills are scoped, named, and documented.
+2. Make workflows predictable and testable.
+3. Reduce prompt ambiguity by establishing explicit rules and failure modes.
+4. Provide templates that turn a user prompt into a production-ready skill package quickly.
+
+## Quick start
+
+1. Read `guides/skill-creation-guide.md` for end-to-end authoring flow.
+2. Pick a template from `tools/templates/`.
+3. Clone one of the starter skills from `skills/`.
+4. Fill in domain-specific details and validation checks.
+
+## Skill directory pattern
+
+```text
+skills/<skill-name>/
+├── SKILL.md
+├── references/
+├── scripts/      (optional)
+└── assets/       (optional)
+```
+
+Use this pattern to keep instructions concise in `SKILL.md`, while moving detailed references and deterministic automation into bundled resources.

--- a/guides/repo-structure-analysis.md
+++ b/guides/repo-structure-analysis.md
@@ -1,0 +1,40 @@
+# AI Skill Repository Structure Analysis
+
+## Common structure in popular skill repos
+
+Across public skill ecosystems, the most resilient pattern is:
+
+1. One folder per skill.
+2. A required `SKILL.md` file as the entrypoint.
+3. Optional but strongly recommended subfolders:
+   - `references/` for domain docs, schemas, policy rules.
+   - `scripts/` for deterministic and repeatable execution.
+   - `assets/` for templates and output resources.
+
+## Semantic layout conventions
+
+- **Top-level by capability**: skills are grouped by domain or task class.
+- **Single responsibility per skill**: avoid broad “do everything” skills.
+- **Frontmatter triggers**: `name` + description encode when the skill should activate.
+- **Thin control layer**: SKILL body defines flow and decision points, not encyclopedic detail.
+
+## Typical quality markers
+
+- Concrete trigger language in description.
+- Explicit input requirements and output contract.
+- Decision branches for normal and failure states.
+- Tight references to reusable resources.
+- Verification commands with pass/fail criteria.
+
+## Document length guidance
+
+- `SKILL.md`: 80–250 lines for most skills.
+- Large domain specifics: move into `references/`.
+- Repetitive mechanics: move into `scripts/`.
+
+## Tooling patterns seen most often
+
+- Search and extraction tools for repository/API context.
+- Local scripts for data cleanup, validation, and scaffolding.
+- Template-driven generation for repeatable outputs.
+- Check scripts for lint/test/build gates.

--- a/guides/rule-creation-guide.md
+++ b/guides/rule-creation-guide.md
@@ -1,0 +1,33 @@
+# Rule Creation Guide
+
+## Goal
+
+Create rules that are enforceable, testable, and minimally ambiguous.
+
+## Rule schema
+
+- **Rule name**
+- **Intent**
+- **Scope**
+- **Hard requirement**
+- **Allowed exceptions**
+- **Validation method**
+- **Violation response**
+
+## Good rule properties
+
+- Binary pass/fail interpretation.
+- Context-aware scope.
+- Low contradiction with adjacent rules.
+- Traceable to a quality or safety objective.
+
+## Priority layering
+
+1. Safety/legal constraints.
+2. System/developer instructions.
+3. Project conventions.
+4. User style preferences.
+
+## Validation strategy
+
+Attach one command or test per critical rule whenever possible.

--- a/guides/skill-creation-guide.md
+++ b/guides/skill-creation-guide.md
@@ -1,0 +1,43 @@
+# Skill Creation Guide
+
+## Purpose
+
+Create a robust skill from a user prompt with minimal back-and-forth and predictable output quality.
+
+## Authoring workflow
+
+1. **Classify request**
+   - Identify domain, scope, and expected artifact.
+2. **Ask clarifying questions**
+   - Collect missing constraints (format, tools, risk tolerance, deadlines).
+3. **Define success contract**
+   - Specify expected outputs and acceptance checks.
+4. **Design structure**
+   - Create `SKILL.md` + only needed resource folders.
+5. **Implement deterministic pieces**
+   - Add scripts for repetitive or fragile operations.
+6. **Validate**
+   - Run checks and include troubleshooting steps.
+
+## Clarifying questions checklist
+
+- What exact output should be produced?
+- What tools can/cannot be used?
+- What quality or policy constraints apply?
+- What edge cases must be handled?
+- What does failure look like?
+
+## SKILL.md standards
+
+- Keep frontmatter precise and trigger-oriented.
+- Write body instructions in imperative style.
+- Include clear execution sequence and branching.
+- Reference external docs instead of duplicating them.
+- Add a verification section with explicit commands.
+
+## Anti-patterns
+
+- Vague “do your best” steps.
+- Huge SKILL files with mixed references.
+- No error handling path.
+- Unclear output destination.

--- a/guides/system-prompting-guide.md
+++ b/guides/system-prompting-guide.md
@@ -1,0 +1,34 @@
+# System Prompting Guide
+
+## Objective
+
+Define system prompts that constrain behavior, preserve flexibility where needed, and reduce hallucination-prone ambiguity.
+
+## Prompt architecture
+
+1. Role and operating context.
+2. Non-negotiable constraints.
+3. Tool usage policy.
+4. Workflow expectations.
+5. Output format contract.
+6. Failure-handling instructions.
+
+## Engineering heuristics
+
+- Put hard constraints early.
+- Use explicit precedence language.
+- Define what to do when info is missing.
+- Require evidence-backed final summaries.
+
+## Common failure modes
+
+- Overly broad role definitions.
+- Missing hierarchy between conflicting instructions.
+- No specified behavior for blocked actions.
+
+## Prompt QA checklist
+
+- Are constraints testable?
+- Are outputs structurally defined?
+- Are trade-offs (speed vs quality) explicit?
+- Is fallback behavior deterministic?

--- a/guides/tool-creation-guide.md
+++ b/guides/tool-creation-guide.md
@@ -1,0 +1,33 @@
+# Tool Creation Guide
+
+## Purpose
+
+Design tools that improve determinism, reduce token overhead, and enforce quality gates inside skill workflows.
+
+## Tool categories
+
+- **Scaffolding tools**: create folder/file skeletons.
+- **Validation tools**: lint, type-check, schema-check, policy-check.
+- **Transformation tools**: convert, format, and normalize data.
+- **Reporting tools**: summarize outputs and diagnostics.
+
+## Implementation standards
+
+- Keep CLI input explicit and strongly typed.
+- Return machine-parsable success/failure messages.
+- Separate pure transformation from side effects.
+- Document examples and failure codes.
+
+## Minimum tool contract
+
+- Inputs and defaults.
+- Output schema.
+- Error modes.
+- Example invocation.
+- Test coverage expectations.
+
+## Integration tips for skills
+
+- Call tools by exact command syntax.
+- Add fallback path when tool fails.
+- Avoid embedding large code snippets when script exists.

--- a/guides/workflow-creation-guide.md
+++ b/guides/workflow-creation-guide.md
@@ -1,0 +1,40 @@
+# Workflow Creation Guide
+
+## Objective
+
+Convert task intent into a repeatable, debuggable sequence that an agent can execute safely.
+
+## Workflow blueprint
+
+1. Input normalization.
+2. Environment/context discovery.
+3. Plan generation.
+4. Execution in bounded steps.
+5. Verification.
+6. Final reporting with evidence.
+
+## Decision design
+
+For each step, document:
+
+- Preconditions.
+- Action.
+- Success criteria.
+- Failure branch.
+- Recovery action.
+
+## Reliability rules
+
+- Prefer small steps over large monolithic actions.
+- Add checkpoints after meaningful state changes.
+- Keep rollback guidance near risky actions.
+- Emit structured output summaries.
+
+## Observability
+
+Track:
+
+- Commands executed.
+- Files changed.
+- Test outcomes.
+- Known limitations.

--- a/skills/skill-authoring/SKILL.md
+++ b/skills/skill-authoring/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: skill-authoring
+description: "Design, draft, and refine SKILL.md-based agent skills with clear trigger criteria, execution flow, validation checks, and reusable references. Use when creating a new skill or improving an existing one."
+---
+
+# Skill Authoring
+
+Define skill scope, build concise instructions, and package reusable context.
+
+## Workflow
+
+1. Extract user intent and expected artifacts.
+2. Ask only the minimum clarifying questions required to avoid rework.
+3. Draft frontmatter with explicit trigger conditions.
+4. Write procedural body instructions with validation and failure handling.
+5. Move domain-heavy detail into `references/`.
+6. Add deterministic utilities in `scripts/` when repetition exists.
+
+## Output Requirements
+
+- Include required frontmatter fields.
+- Keep action steps ordered and testable.
+- Include at least one verification section.
+- Avoid redundant reference duplication.
+
+## References
+
+Load `references/checklist.md` before finalizing output.

--- a/skills/skill-authoring/references/checklist.md
+++ b/skills/skill-authoring/references/checklist.md
@@ -1,0 +1,7 @@
+# Skill Review Checklist
+
+- Does description clearly state when to use the skill?
+- Are the execution steps ordered and imperative?
+- Are output artifacts explicitly named?
+- Are validation commands provided?
+- Are failure branches documented?

--- a/skills/system-prompt-engineer/SKILL.md
+++ b/skills/system-prompt-engineer/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: system-prompt-engineer
+description: "Author and review system prompts for agent behavior control, instruction precedence, safety constraints, and output contracts. Use when defining or auditing operational prompts for reliability."
+---
+
+# System Prompt Engineer
+
+Build high-clarity prompts that reduce ambiguity and enforce policy.
+
+## Authoring Flow
+
+1. Declare role and domain context.
+2. List non-negotiable constraints and precedence.
+3. Specify tool usage and prohibited actions.
+4. Define required output format and evidence rules.
+5. Add fallback behavior for unknowns and blocked operations.
+
+## Validation
+
+- Test prompt against at least three realistic scenarios.
+- Verify precedence handling under conflicting instructions.
+- Confirm output is structurally consistent.
+
+## References
+
+Load `references/prompt-audit.md` to perform prompt quality review.

--- a/skills/system-prompt-engineer/references/prompt-audit.md
+++ b/skills/system-prompt-engineer/references/prompt-audit.md
@@ -1,0 +1,9 @@
+# Prompt Audit
+
+## Questions
+
+- Are constraints prioritized and conflict-safe?
+- Are required tools and forbidden tools explicit?
+- Is failure behavior deterministic?
+- Is response format concrete?
+- Are safety and privacy constraints enforceable?

--- a/skills/workflow-planner/SKILL.md
+++ b/skills/workflow-planner/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: workflow-planner
+description: "Transform user requests into structured execution plans with checkpoints, branch logic, and verification gates. Use when tasks need multi-step orchestration and clear progress tracking."
+---
+
+# Workflow Planner
+
+Create reliable execution plans for agentic tasks.
+
+## Plan Construction
+
+1. Define task objective and constraints.
+2. Break work into sequential milestones.
+3. Attach preconditions and success checks to each milestone.
+4. Add recovery branches for expected failure modes.
+5. Emit a final checklist that confirms completion.
+
+## Quality Rules
+
+- Keep one active step at a time.
+- Prefer short, testable actions.
+- Include explicit evidence requirements.
+
+## References
+
+Load `references/branching-patterns.md` for failure-handling patterns.

--- a/skills/workflow-planner/references/branching-patterns.md
+++ b/skills/workflow-planner/references/branching-patterns.md
@@ -1,0 +1,13 @@
+# Branching Patterns
+
+## Standard branch
+
+- If check passes: continue to next step.
+- If check fails: stop, capture diagnostics, apply recovery action, then re-check.
+
+## Recovery template
+
+1. Identify failure source.
+2. Apply smallest corrective action.
+3. Re-run only impacted checks.
+4. Continue or escalate with clear reason.

--- a/tools/templates/SKILL.template.md
+++ b/tools/templates/SKILL.template.md
@@ -1,0 +1,20 @@
+---
+name: <skill-name>
+description: "<what the skill does + when to use it>"
+---
+
+# <Skill Title>
+
+## Workflow
+
+1. <step 1>
+2. <step 2>
+3. <step 3>
+
+## Validation
+
+- <command or check>
+
+## References
+
+- <reference-file>

--- a/tools/templates/system-prompt.template.md
+++ b/tools/templates/system-prompt.template.md
@@ -1,0 +1,25 @@
+# System Prompt Template
+
+## Role
+
+<role and scope>
+
+## Constraints
+
+1. <non-negotiable rule>
+2. <non-negotiable rule>
+
+## Tool Policy
+
+- Allowed: <...>
+- Disallowed: <...>
+
+## Output Contract
+
+- Format: <...>
+- Evidence required: <...>
+
+## Fallback Behavior
+
+- If missing context: <...>
+- If blocked: <...>

--- a/tools/templates/workflow.template.md
+++ b/tools/templates/workflow.template.md
@@ -1,0 +1,17 @@
+# Workflow Template
+
+## Objective
+
+<clear task objective>
+
+## Steps
+
+1. Preconditions: <...>
+   Action: <...>
+   Success check: <...>
+   Failure branch: <...>
+
+2. Preconditions: <...>
+   Action: <...>
+   Success check: <...>
+   Failure branch: <...>


### PR DESCRIPTION
### Motivation
- Provide a clear playbook and starter assets for authoring `SKILL.md`-based AI skills and agent workflows so new skills can be created consistently. 
- Reduce prompt ambiguity and make skill creation repeatable by collecting best-practice patterns (structure, prompting, rules, tools, and workflows). 

### Description
- Expand `README.md` with purpose, quick-start, and canonical skill directory pattern for `SKILL.md`-based skills. 
- Add a `guides/` suite with authored guidance files: `repo-structure-analysis.md`, `skill-creation-guide.md`, `workflow-creation-guide.md`, `tool-creation-guide.md`, `rule-creation-guide.md`, and `system-prompting-guide.md`. 
- Add three starter skills under `skills/` (`skill-authoring`, `workflow-planner`, `system-prompt-engineer`) each with a `SKILL.md` frontmatter and small `references/` artifacts. 
- Add reusable authoring templates under `tools/templates/` for `SKILL`, workflow, and system-prompt drafting (`SKILL.template.md`, `workflow.template.md`, `system-prompt.template.md`). 

### Testing
- Verified repository file discovery with `rg --files` to confirm expected files and directories are present. 
- Ran a Python frontmatter validation (`SKILL.md` frontmatter check) across `skills/*/SKILL.md` which returned `PASS` for required `name` and `description` fields. 
- Performed basic content inspection (printed key files) to ensure templates and guide files contain the intended sections and links, and found no validation errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f2c830c648331aa0f11a98a8d4f8c)