### PR TITLE
Add SolidJS workflow skills with concise SKILL.md and focused references

### DIFF
--- a/skills/solid-component-builder/SKILL.md
+++ b/skills/solid-component-builder/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: solid-component-builder
+description: "Build production-ready SolidJS components from explicit UI and behavior requirements. Use when creating or extending Solid components, props contracts, styling hooks, and accessibility semantics."
+---
+
+# Solid Component Builder
+
+Create focused SolidJS components with deterministic structure and stable public API.
+
+## Trigger Conditions
+
+Use this skill when the user asks to:
+- Create a new Solid component (presentational or stateful).
+- Add props, slots (`children`), or event callbacks to an existing component.
+- Implement accessibility-aware UI behavior in Solid.
+- Convert UI requirements into Solid JSX + TypeScript component code.
+
+Do **not** use when the primary request is project bootstrapping, large-scale refactor planning, or architecture review.
+
+## Input Contract (Required)
+
+Collect or infer these fields before coding:
+1. `component_name` (PascalCase)
+2. `purpose` (1 sentence)
+3. `props` (name, type, required/optional, default behavior)
+4. `state_and_events` (signals, handlers, derived values)
+5. `render_constraints` (conditional branches, lists, empty states)
+6. `styling_strategy` (CSS module, utility classes, inline)
+7. `a11y_requirements` (labels, roles, keyboard support)
+
+If any required field is missing and cannot be safely inferred, stop and return a blocked response.
+
+## Output Contract (Required)
+
+Return:
+1. Final component implementation.
+2. Prop contract summary table.
+3. Explicit assumptions list.
+4. Verification notes mapped to checklist items.
+
+## Deterministic Checklist
+
+1. Validate `component_name` and prop names are consistent.
+2. Ensure each prop is used or documented as intentionally unused.
+3. Ensure signal usage is minimal and local.
+4. Ensure control flow uses Solid primitives (`<Show>`, `<For>`, `<Switch>`) where appropriate.
+5. Ensure event handlers are stable and typed.
+6. Ensure accessibility attributes/labels match behavior.
+7. Ensure output includes no dead imports or placeholder text.
+
+## Failure Modes
+
+- **Ambiguous behavior spec**: refuse to guess interaction semantics.
+- **Contradictory prop rules**: ask for precedence or return blocked.
+- **Missing accessibility requirement for interactive UI**: mark incomplete and block finalization.
+- **Over-coupled component scope**: split into child components and report rationale.
+
+## References
+
+Load only when needed:
+- `references/component-contract-template.md` for prop/event contract format.
+- `references/solid-rendering-checklist.md` for rendering and reactivity guardrails.

--- a/skills/solid-component-builder/references/component-contract-template.md
+++ b/skills/solid-component-builder/references/component-contract-template.md
@@ -1,0 +1,15 @@
+# Component Contract Template
+
+Use this schema to document component API:
+
+| Prop | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `name` | `string` | yes/no | value or `n/a` | concise behavior note |
+
+Event callback notation:
+- `onAction?: (payload: PayloadType) => void`
+- Document when callback fires and payload shape.
+
+Children contract:
+- Specify if `children` is required, optional, or ignored.
+- Specify expected semantic container.

--- a/skills/solid-component-builder/references/solid-rendering-checklist.md
+++ b/skills/solid-component-builder/references/solid-rendering-checklist.md
@@ -1,0 +1,7 @@
+# Solid Rendering Checklist
+
+1. Prefer `<Show>` over ternaries for non-trivial conditional branches.
+2. Prefer `<For>` for list rendering with stable item keys when available.
+3. Keep `createSignal` near usage; avoid global mutable state in component files.
+4. Derive values with `createMemo` only when recomputation cost/clarity justifies it.
+5. Avoid React-only patterns (`useEffect`, `setState` semantics).

--- a/skills/solid-design-patterns/SKILL.md
+++ b/skills/solid-design-patterns/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: solid-design-patterns
+description: "Apply SolidJS-specific design patterns for state, composition, data flow, and UI architecture. Use when selecting or implementing maintainable patterns across Solid components and modules."
+---
+
+# Solid Design Patterns
+
+Select and apply Solid-native patterns with explicit tradeoffs.
+
+## Trigger Conditions
+
+Use this skill when the user asks to:
+- Choose architecture or composition patterns for Solid features.
+- Standardize state and data-flow approaches across components.
+- Compare alternatives and justify one pattern for a use case.
+
+Do **not** use for one-off bug fixes with no architectural impact.
+
+## Input Contract (Required)
+
+Require:
+1. `problem_statement`
+2. `current_constraints` (team size, performance, SSR, etc.)
+3. `scope` (single component, feature module, app-wide)
+4. `decision_drivers` (readability, performance, testability, velocity)
+5. `forbidden_patterns` (optional)
+
+If decision drivers are missing, assume readability + correctness and state that.
+
+## Output Contract (Required)
+
+Return:
+1. Recommended pattern with concise rationale.
+2. Rejected alternatives with reason.
+3. Implementation sketch (files or pseudocode-level steps).
+4. Adoption checklist and rollback criteria.
+
+## Deterministic Checklist
+
+1. Map each recommendation to at least one decision driver.
+2. Prefer Solid-native primitives over framework-transplanted patterns.
+3. Define state ownership boundaries and update pathways.
+4. Clarify scaling behavior under increased complexity.
+5. Include migration/rollback path for existing code.
+
+## Failure Modes
+
+- **No concrete constraints**: provide two bounded options, mark provisional decision.
+- **Pattern mismatch to scope**: downscope recommendation and flag architectural debt.
+- **Unclear ownership boundaries**: block final recommendation until boundaries are defined.
+- **Tradeoffs omitted**: incomplete result; must include downside analysis.
+
+## References
+
+Load only when needed:
+- `references/pattern-selection-matrix.md` for decision mapping.
+- `references/solid-pattern-catalog.md` for concise pattern definitions.

--- a/skills/solid-design-patterns/references/pattern-selection-matrix.md
+++ b/skills/solid-design-patterns/references/pattern-selection-matrix.md
@@ -1,0 +1,8 @@
+# Pattern Selection Matrix
+
+| Driver | Prefer | Avoid |
+|---|---|---|
+| Local UI state clarity | Component-local signals | Global store by default |
+| Shared cross-feature state | Context/store with clear boundaries | Prop drilling across many layers |
+| Expensive derived values | Memoized derivations | Recompute per render branch |
+| Complex async orchestration | Resource-based separation + explicit status | Ad-hoc effect chains |

--- a/skills/solid-design-patterns/references/solid-pattern-catalog.md
+++ b/skills/solid-design-patterns/references/solid-pattern-catalog.md
@@ -1,0 +1,6 @@
+# Solid Pattern Catalog
+
+- **Local Signal Ownership**: Keep transient state near rendering component.
+- **Context Boundary Pattern**: Expose controlled read/write API via context provider.
+- **Resource Status Envelope**: Standardize loading/success/error rendering contract.
+- **Headless Component Pattern**: Separate behavior logic from visual composition.

--- a/skills/solid-refactor-assistant/SKILL.md
+++ b/skills/solid-refactor-assistant/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: solid-refactor-assistant
+description: "Refactor SolidJS code safely with behavior parity, clearer reactive boundaries, and reduced complexity. Use when reorganizing components, stores, and reactive logic without changing product intent."
+---
+
+# Solid Refactor Assistant
+
+Refactor SolidJS code with deterministic safety checks and explicit non-goals.
+
+## Trigger Conditions
+
+Use this skill when the user asks to:
+- Improve readability/maintainability of existing Solid files.
+- Split large components/composables into smaller units.
+- Remove anti-patterns or dead code while preserving behavior.
+- Standardize reactive logic and state ownership.
+
+Do **not** use for greenfield component creation or full project scaffolding.
+
+## Input Contract (Required)
+
+Require:
+1. `target_files`
+2. `refactor_goal` (complexity, naming, separation, performance)
+3. `non_goals` (what must not change)
+4. `behavioral_invariants` (UI/output/interaction that must remain)
+5. `risk_tolerance` (`low`, `medium`, `high`)
+
+If invariants are absent, infer from existing behavior and mark assumptions.
+
+## Output Contract (Required)
+
+Return:
+1. Refactor plan (ordered steps).
+2. Applied changes with before/after rationale.
+3. Risk report listing touched invariants.
+4. Verification checklist outcomes.
+
+## Deterministic Checklist
+
+1. Preserve public props/events and exported symbols unless approved.
+2. Keep reactive dependencies explicit and localized.
+3. Remove unused imports, signals, and helper functions.
+4. Reduce nesting/branch complexity where possible.
+5. Keep naming consistent with existing codebase conventions.
+6. Re-run checks/tests and report deltas.
+
+## Failure Modes
+
+- **No measurable refactor goal**: block and request concrete target.
+- **Invariant conflicts with requested change**: prioritize invariants and report blocked items.
+- **High-risk file coupling discovered**: downscope to safe subset and report deferred work.
+- **Behavior parity unverified**: mark as incomplete; do not claim safe refactor.
+
+## References
+
+Load only when needed:
+- `references/refactor-strategy-matrix.md` for choosing safe refactor shape.
+- `references/solid-reactivity-smells.md` for common Solid anti-patterns.

--- a/skills/solid-refactor-assistant/references/refactor-strategy-matrix.md
+++ b/skills/solid-refactor-assistant/references/refactor-strategy-matrix.md
@@ -1,0 +1,8 @@
+# Refactor Strategy Matrix
+
+| Goal | Primary Tactic | Safety Constraint |
+|---|---|---|
+| Reduce file size | Extract child components/hooks | Keep external API unchanged |
+| Clarify state flow | Move state closer to consumer | Preserve event timing |
+| Remove duplication | Consolidate utility functions | Maintain type signatures |
+| Improve naming | Rename in small batches | Verify all call sites |

--- a/skills/solid-refactor-assistant/references/solid-reactivity-smells.md
+++ b/skills/solid-refactor-assistant/references/solid-reactivity-smells.md
@@ -1,0 +1,7 @@
+# Solid Reactivity Smells
+
+- Signal created but never read.
+- `createEffect` used for derivation that should be `createMemo`.
+- Mutating objects in place without notifying dependents.
+- Large components mixing data-fetching and deep rendering branches.
+- Hidden dependencies captured in closures causing stale reads.

--- a/skills/solid-reviewer/SKILL.md
+++ b/skills/solid-reviewer/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: solid-reviewer
+description: "Review SolidJS code changes for correctness, reactivity safety, accessibility, and maintainability with actionable findings. Use when auditing pull requests or local diffs in Solid projects."
+---
+
+# Solid Reviewer
+
+Perform strict, evidence-based reviews for SolidJS changes.
+
+## Trigger Conditions
+
+Use this skill when the user asks to:
+- Review Solid-related diffs or pull requests.
+- Identify bugs, reactive hazards, or maintainability issues.
+- Provide merge readiness assessment.
+
+Do **not** use for implementing requested features directly.
+
+## Input Contract (Required)
+
+Require:
+1. `diff_scope` (files or commit range)
+2. `review_focus` (correctness, performance, a11y, API stability)
+3. `severity_scheme` (`critical`, `major`, `minor`)
+4. `release_context` (optional risk context)
+
+If no diff is provided, review cannot proceed.
+
+## Output Contract (Required)
+
+Return:
+1. Findings list grouped by severity.
+2. For each finding: evidence, impact, and recommended fix.
+3. Explicit list of checks performed.
+4. Final recommendation: `approve`, `approve-with-notes`, or `request-changes`.
+
+## Deterministic Checklist
+
+1. Validate Solid primitive usage and reactive correctness.
+2. Validate control-flow rendering and list behavior.
+3. Validate type-safety/public interface changes.
+4. Validate accessibility for interactive elements.
+5. Validate test or verification coverage for changed behavior.
+6. Validate no obvious dead code/debug artifacts.
+
+## Failure Modes
+
+- **Incomplete diff scope**: return partial review + explicit gap list.
+- **No reproducible evidence**: downgrade certainty and avoid definitive claims.
+- **Missing severity mapping**: apply default scheme and state it.
+- **Unsupported environment for checks**: report limitation, keep code review static.
+
+## References
+
+Load only when needed:
+- `references/review-severity-rubric.md` for consistent prioritization.
+- `references/solid-pr-review-checks.md` for Solid-focused audit prompts.

--- a/skills/solid-reviewer/references/review-severity-rubric.md
+++ b/skills/solid-reviewer/references/review-severity-rubric.md
@@ -1,0 +1,7 @@
+# Review Severity Rubric
+
+- **Critical**: likely production failure, security issue, or data loss.
+- **Major**: user-visible bug, API break, substantial performance/a11y regression.
+- **Minor**: clarity, maintainability, or low-risk edge-case issue.
+
+Escalate severity when issue affects shared components or core routing flows.

--- a/skills/solid-reviewer/references/solid-pr-review-checks.md
+++ b/skills/solid-reviewer/references/solid-pr-review-checks.md
@@ -1,0 +1,7 @@
+# Solid PR Review Checks
+
+1. Are signals/memos/effects used for the right purpose?
+2. Are asynchronous flows cancel-safe and race-aware?
+3. Are conditional/list branches robust for empty/loading/error states?
+4. Are semantic HTML and labels present for controls?
+5. Are exported types/components backward compatible?

--- a/skills/solid-scaffold-bootstrap/SKILL.md
+++ b/skills/solid-scaffold-bootstrap/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: solid-scaffold-bootstrap
+description: "Bootstrap SolidJS project scaffolds with deterministic structure, baseline tooling, and optional feature presets. Use when initializing new Solid repos or adding standardized project foundations."
+---
+
+# Solid Scaffold Bootstrap
+
+Create consistent SolidJS project foundations with explicit options and reproducible setup.
+
+## Trigger Conditions
+
+Use this skill when the user asks to:
+- Initialize a new Solid project.
+- Add baseline tooling (lint, format, test, CI skeleton).
+- Apply a standard folder structure or starter preset.
+
+Do **not** use for feature-level component implementation or deep refactors.
+
+## Input Contract (Required)
+
+Require:
+1. `project_name`
+2. `package_manager` (`npm`/`pnpm`/`yarn`)
+3. `language` (`ts` or `js`)
+4. `tooling_options` (lint/test/format/router/state)
+5. `deployment_target` (optional)
+6. `constraints` (enterprise policy or minimal deps)
+
+If package manager or language is missing, default and state assumptions.
+
+## Output Contract (Required)
+
+Return:
+1. Scaffold plan with concrete commands.
+2. Files/folders created or modified.
+3. Post-setup verification commands.
+4. Deferred optional improvements list.
+
+## Deterministic Checklist
+
+1. Use a single package manager consistently.
+2. Ensure scripts (`dev`, `build`, `test`, `lint`) are coherent with installed tools.
+3. Ensure directory structure matches declared preset.
+4. Ensure starter app compiles/runs.
+5. Ensure README/setup notes reflect actual commands.
+
+## Failure Modes
+
+- **Conflicting tooling selections**: choose minimal compatible set and report dropped options.
+- **Template command unavailable**: provide equivalent fallback and mark divergence.
+- **Dependency installation failure**: keep generated files, report exact failing step.
+- **Undeclared runtime constraints**: block production claims and request constraint details.
+
+## References
+
+Load only when needed:
+- `references/scaffold-presets.md` for baseline project layouts.
+- `references/tooling-compatibility.md` for package/tool compatibility rules.

--- a/skills/solid-scaffold-bootstrap/references/scaffold-presets.md
+++ b/skills/solid-scaffold-bootstrap/references/scaffold-presets.md
@@ -1,0 +1,14 @@
+# Scaffold Presets
+
+## Minimal
+- `src/App.tsx`
+- `src/index.tsx`
+- `public/`
+- Basic scripts: `dev`, `build`
+
+## Standard
+- Minimal + lint + format + unit test setup
+- `src/components/`, `src/lib/`, `src/styles/`
+
+## Full
+- Standard + routing + CI skeleton + contribution docs

--- a/skills/solid-scaffold-bootstrap/references/tooling-compatibility.md
+++ b/skills/solid-scaffold-bootstrap/references/tooling-compatibility.md
@@ -1,0 +1,6 @@
+# Tooling Compatibility
+
+- Prefer TypeScript for reusable component libraries.
+- Align linter/formatter plugins with Solid JSX syntax support.
+- Keep test runner and DOM environment compatible with selected tooling.
+- Avoid mixing multiple formatters or overlapping lint rule packs.


### PR DESCRIPTION
### Motivation

- Provide a focused set of SolidJS-oriented skills to standardize component creation, refactors, reviews, scaffolding, and design-pattern decisions.
- Keep each skill lightweight in-context by moving larger details into small `references/` files and defining precise trigger/input/output contracts.
- Reduce ambiguity in agent behavior by adding deterministic checklists and explicit failure modes for each SolidJS workflow.

### Description

- Add five new skill directories under `skills/`: `solid-component-builder`, `solid-refactor-assistant`, `solid-reviewer`, `solid-scaffold-bootstrap`, and `solid-design-patterns`, each with a `SKILL.md` that includes frontmatter, trigger conditions, input/output contracts, deterministic checklists, and failure modes.
- Add compact `references/` documents per skill (contract templates, rendering checklist, refactor matrix, reactivity smells, review rubric/checks, scaffold presets, tooling compatibility, and pattern maps) and link only those from their `SKILL.md` to keep context loading tight.
- Ensure all `SKILL.md` files begin with required YAML frontmatter and that skill folder names follow the naming convention.
- This change is documentation/skill-pack only and introduces no runtime code or behavioral changes.

### Testing

- Ran `git status --short && rg --files skills/solid-*` to confirm the new directories and files are present, which succeeded.
- Ran `for f in skills/solid-*/SKILL.md; do echo "checking $f"; awk 'NR==1{print $0}' "$f"; done` to verify each `SKILL.md` has frontmatter, which succeeded.
- Committed the changes with `git commit -m "Add SolidJS workflow skill packs with focused references"`, producing a commit that added the files (commit reported 15 files changed and 378 insertions), which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f5406261083318c11a28b4938a347)