### PR TITLE
Add SolidJS domain guides under guides/

### DIFF
--- a/guides/solid-bootstrap-guide.md
+++ b/guides/solid-bootstrap-guide.md
@@ -1,0 +1,62 @@
+# SolidJS Bootstrap Guide
+
+## Purpose
+
+Bootstrap a new SolidJS application or domain area with reliable defaults for architecture, quality checks, and team onboarding.
+
+## Decision criteria and tradeoffs
+
+- **Starter simplicity vs production readiness**
+  - Simple starters maximize onboarding speed.
+  - Production-ready setups reduce future migration effort.
+- **Convention strictness vs flexibility**
+  - Strong conventions improve consistency and review speed.
+  - Excessive strictness can slow experimentation in early stages.
+- **Tooling depth**
+  - Minimal tooling keeps setup lightweight.
+  - Rich tooling (lint/type/test/CI) catches defects earlier.
+- **State strategy at bootstrap**
+  - Keep initial state local until sharing needs are proven.
+  - Early global state setup can help if cross-feature coordination is expected.
+
+## Step-by-step workflow
+
+1. **Initialize project foundation**
+   - Create app with approved SolidJS starter and package manager.
+2. **Configure quality gates**
+   - Add linting, formatting, type-checking, and test scripts.
+3. **Establish folder architecture**
+   - Define core directories for components, routes, state, and utilities.
+4. **Create baseline app shell**
+   - Add layout, navigation, and not-found/error boundaries.
+5. **Set up data and state patterns**
+   - Document preferred signal/store/context usage patterns.
+6. **Add CI-ready scripts**
+   - Ensure checks run reproducibly in local and CI environments.
+7. **Seed developer documentation**
+   - Add getting-started, coding conventions, and PR expectations.
+8. **Verify onboarding flow**
+   - Validate that a new contributor can install, run, and validate quickly.
+
+## Code smells and anti-patterns
+
+- Bootstrapping without lint/type/test scripts.
+- Early adoption of heavy architecture without concrete need.
+- Inconsistent folder and naming conventions from the first commit.
+- Missing error boundaries and fallback UX states.
+- Hidden setup steps not captured in documentation.
+- CI pipeline that diverges from local developer workflows.
+
+## Validation checklist
+
+- App installs and runs with documented commands.
+- Quality checks are available and passing.
+- Directory structure and conventions are documented.
+- Baseline UX handles loading and failure paths.
+- CI scripts align with local scripts.
+- New contributors can follow setup docs without tribal knowledge.
+- Initial architecture choices include rationale and tradeoffs.
+
+## Done definition (PR quality)
+
+A bootstrap PR is done when the project starts from a stable, documented, and enforceable foundation: contributors can get productive quickly, quality gates are operational, and core architectural choices are explicit enough to scale safely.

--- a/guides/solid-component-design-guide.md
+++ b/guides/solid-component-design-guide.md
@@ -1,0 +1,66 @@
+# SolidJS Component Design Guide
+
+## Purpose
+
+Design SolidJS components that stay easy to reason about as state, composition, and performance demands grow.
+
+## Decision criteria and tradeoffs
+
+- **Component boundary size**
+  - Prefer smaller boundaries when logic can be shared and independently tested.
+  - Prefer larger boundaries when splitting would increase prop drilling and coordination overhead.
+- **Props vs context vs stores**
+  - Start with props for explicit dependencies.
+  - Introduce context for deeply shared dependencies within a subtree.
+  - Use stores/signals for shared reactive state; avoid global state by default.
+- **Presentational vs smart components**
+  - Keep UI-only components presentational and data-agnostic.
+  - Keep data loading, mutations, and side-effects in smart/container layers.
+- **Reactivity granularity**
+  - Fine-grained signals minimize rerenders and improve responsiveness.
+  - Too many micro-signals can reduce readability if naming and ownership are unclear.
+- **Composition strategy**
+  - Prefer composition slots/children over flag-based branching for extensibility.
+  - Excessive composition layers can make control flow harder to discover.
+
+## Step-by-step workflow
+
+1. **Define responsibilities**
+   - Write a 1–2 sentence contract for what the component owns.
+2. **Map data flow**
+   - Identify inputs, derived state, and output events.
+3. **Choose state placement**
+   - Place state at the lowest level that needs to own changes.
+4. **Design the public API**
+   - Keep props minimal, typed, and intention-revealing.
+5. **Implement with Solid primitives**
+   - Use `createSignal`, `createMemo`, and `createEffect` deliberately.
+6. **Split view from behavior**
+   - Extract reusable rendering parts and logic helpers where beneficial.
+7. **Evaluate render behavior**
+   - Confirm reactivity updates only where expected.
+8. **Document assumptions**
+   - Add comments for non-obvious lifecycle or reactivity decisions.
+
+## Code smells and anti-patterns
+
+- Props with vague names (`data`, `item`, `config`) and unclear shape.
+- Components that fetch data, normalize data, and render complex UI all together.
+- `createEffect` used for value derivation that should be `createMemo`.
+- Hidden coupling to external stores without explicit contract.
+- Boolean prop explosions (`isCompact`, `isSimple`, `isCard`, `isInline`) instead of composition.
+- Multiple unrelated responsibilities in one component file.
+
+## Validation checklist
+
+- Component has a clear single responsibility.
+- Public props are minimal and strongly typed.
+- Side-effects are isolated and justified.
+- Derived values use `createMemo` instead of imperative mutation.
+- Conditional rendering paths are understandable and covered.
+- Accessibility semantics (labels, roles, keyboard behavior) are preserved.
+- Component can be reused without pulling hidden dependencies.
+
+## Done definition (PR quality)
+
+A PR is done when component boundaries are explicit, reactivity choices are intentional, and the API is easy for another engineer to consume without reverse engineering internal state flow. The PR should include rationale for tradeoffs, evidence that render behavior is predictable, and a concise checklist confirming maintainability and accessibility expectations.

--- a/guides/solid-refactoring-guide.md
+++ b/guides/solid-refactoring-guide.md
@@ -1,0 +1,62 @@
+# SolidJS Refactoring Guide
+
+## Purpose
+
+Refactor SolidJS code safely while improving clarity, reusability, and reactive performance.
+
+## Decision criteria and tradeoffs
+
+- **Incremental vs broad refactor**
+  - Incremental changes reduce risk and simplify review.
+  - Broad rewrites can remove systemic complexity faster but increase regression risk.
+- **Behavior preservation vs API cleanup**
+  - Preserve behavior first when risk is high.
+  - Bundle API cleanup only when migration cost is clear and documented.
+- **Extraction depth**
+  - Extract reusable hooks/helpers when duplication is recurring.
+  - Avoid over-extraction that hides local intent.
+- **Performance focus**
+  - Optimize reactive hotspots that are measured or user-visible.
+  - Avoid speculative micro-optimizations without evidence.
+
+## Step-by-step workflow
+
+1. **Establish current baseline**
+   - Capture existing behavior and key user flows.
+2. **Identify refactor targets**
+   - Prioritize highest-maintenance or highest-risk modules.
+3. **Define non-negotiables**
+   - List behaviors that must not change.
+4. **Refactor in slices**
+   - Separate structural cleanup, naming cleanup, and logic changes.
+5. **Preserve contracts**
+   - Maintain prop/event signatures unless intentionally versioned.
+6. **Re-check reactive semantics**
+   - Verify effects, memos, and signals still update at the right granularity.
+7. **Run validation and compare**
+   - Ensure baseline flows behave the same or better.
+8. **Document migration notes**
+   - Add reviewer notes for any contract or pattern shifts.
+
+## Code smells and anti-patterns
+
+- Big-bang rewrites without incremental checkpoints.
+- Mixing behavior changes with formatting-only churn in one commit.
+- Leaving dead signals/effects after extraction.
+- Renaming symbols without improving clarity or consistency.
+- Replacing explicit data flow with implicit global state.
+- Ignoring obsolete comments/docs after code movement.
+
+## Validation checklist
+
+- Baseline behavior remains intact for core flows.
+- Diff is organized into reviewable logical chunks.
+- Removed duplication results in clearer ownership.
+- No orphaned imports, effects, or helper utilities remain.
+- Updated names improve readability and consistency.
+- Any API changes include migration guidance.
+- Performance is unchanged or improved for targeted paths.
+
+## Done definition (PR quality)
+
+A refactoring PR is done when it reduces complexity without ambiguity, preserves agreed behavior, and gives reviewers confidence through scoped commits, explicit tradeoff notes, and validation evidence that no reactive regressions were introduced.

--- a/guides/solid-review-guide.md
+++ b/guides/solid-review-guide.md
@@ -1,0 +1,62 @@
+# SolidJS Review Guide
+
+## Purpose
+
+Review SolidJS pull requests with a consistent framework that balances correctness, maintainability, and product impact.
+
+## Decision criteria and tradeoffs
+
+- **Correctness vs delivery speed**
+  - Block on defects that can cause user-facing breakage or data inconsistency.
+  - Defer non-critical polish with explicit follow-up issues.
+- **Readability vs cleverness**
+  - Prefer understandable reactive flows over condensed abstractions.
+  - Allow complex patterns only when documented and justified.
+- **Strictness vs momentum**
+  - Enforce architectural constraints that protect long-term quality.
+  - Avoid style-only blocking comments if lint/format already covers them.
+- **Local optimization vs system consistency**
+  - Accept local compromises when they align with shared conventions.
+  - Reject isolated patterns that increase cognitive load repo-wide.
+
+## Step-by-step workflow
+
+1. **Scan intent first**
+   - Read PR summary and confirm claimed scope.
+2. **Review architecture and boundaries**
+   - Check state ownership, component responsibilities, and coupling.
+3. **Inspect reactive correctness**
+   - Validate `createSignal`/`createMemo`/`createEffect` usage.
+4. **Check UI and accessibility impact**
+   - Verify semantics, keyboard flow, and conditional rendering behavior.
+5. **Evaluate test and validation evidence**
+   - Confirm core paths are covered by tests or explicit manual checks.
+6. **Assess maintainability**
+   - Evaluate naming, file structure, and future extension cost.
+7. **Leave prioritized feedback**
+   - Separate blocking issues from suggestions.
+8. **Approve only with clear confidence**
+   - Ensure tradeoffs are documented and acceptable.
+
+## Code smells and anti-patterns
+
+- Review comments focused only on formatting while logic risks remain unaddressed.
+- Unchallenged side-effects in render-critical paths.
+- Missing rationale for non-obvious reactive patterns.
+- Silent acceptance of large mixed-purpose diffs.
+- “Works on my machine” approvals without reproducible checks.
+- Vague feedback with no concrete remediation direction.
+
+## Validation checklist
+
+- PR scope matches implementation.
+- State changes and side-effects are predictable.
+- Failure and empty states are handled.
+- Accessibility expectations are preserved.
+- Tests/manual checks are adequate for risk level.
+- Reviewer feedback is actionable and prioritized.
+- Approval rationale is explicit.
+
+## Done definition (PR quality)
+
+A review is done when the reviewer can clearly articulate why the change is safe to merge, what tradeoffs were accepted, and which risks remain (if any), with concrete evidence that reactive behavior, UX quality, and maintainability standards were evaluated.

--- a/guides/solid-scaffolding-guide.md
+++ b/guides/solid-scaffolding-guide.md
@@ -1,0 +1,62 @@
+# SolidJS Scaffolding Guide
+
+## Purpose
+
+Scaffold new SolidJS features or modules in a way that establishes maintainable defaults from day one.
+
+## Decision criteria and tradeoffs
+
+- **Template reuse vs customization**
+  - Reuse known templates to reduce inconsistency and setup errors.
+  - Customize only where feature constraints demand divergence.
+- **Speed vs completeness**
+  - Start with minimal viable scaffolding for rapid iteration.
+  - Include additional structure early when requirements are stable.
+- **Folder granularity**
+  - Keep structure shallow for small features.
+  - Introduce subfolders when ownership and growth justify it.
+- **Abstraction level**
+  - Begin with direct Solid patterns.
+  - Add wrappers/utilities only after repeated usage emerges.
+
+## Step-by-step workflow
+
+1. **Define feature scope**
+   - Clarify routes, state needs, and integration boundaries.
+2. **Create baseline files**
+   - Add component, styles, tests, and index exports as needed.
+3. **Set naming conventions**
+   - Apply consistent naming for files, components, and signals.
+4. **Wire data dependencies**
+   - Add placeholder props/context/store boundaries.
+5. **Add default UX states**
+   - Include loading, empty, and error states from the start.
+6. **Establish test hooks**
+   - Prepare selectors and test seams for key flows.
+7. **Run baseline checks**
+   - Ensure scaffold compiles and passes lint/type checks.
+8. **Document extension points**
+   - Note where future logic should be added.
+
+## Code smells and anti-patterns
+
+- Copy-pasted scaffolds with stale names and unrelated dependencies.
+- Deep folder nesting before feature complexity warrants it.
+- Missing exports that force brittle relative imports.
+- Scaffolding without empty/error/loading placeholders.
+- Implicit coupling to app-wide stores in initial skeleton.
+- Placeholder code committed without TODO ownership.
+
+## Validation checklist
+
+- Generated structure matches feature scope.
+- Naming is consistent with repository conventions.
+- Public exports are discoverable and stable.
+- Baseline states (loading/empty/error) exist.
+- New files compile and pass static checks.
+- Testability is considered in component structure.
+- Follow-up TODOs are explicit and actionable.
+
+## Done definition (PR quality)
+
+A scaffolding PR is done when it provides a clean, convention-aligned starting point that compiles, is test-ready, and makes future feature work faster without introducing accidental architectural debt.


### PR DESCRIPTION
### Motivation

- Provide a consistent set of SolidJS guidance documents to standardize component design, refactoring, review, scaffolding, and bootstrap practices.
- Reduce onboarding and review friction by capturing decision criteria, tradeoffs, and PR quality expectations for SolidJS work.
- Ensure teams have concrete workflows and validation checklists that minimize reactive/UX regressions.

### Description

- Added five new guides under `guides/`: `solid-component-design-guide.md`, `solid-refactoring-guide.md`, `solid-review-guide.md`, `solid-scaffolding-guide.md`, and `solid-bootstrap-guide.md`.
- Each guide contains Decision criteria and tradeoffs, a Step-by-step workflow, Code smells and anti-patterns, a Validation checklist, and a "Done definition" for PR quality.
- Files follow a consistent structure and language to make them easy to consume and reference during design, refactor, and review cycles.
- Guides are authored as Markdown and placed in the repository `guides/` folder for immediate use.

### Testing

- Verified the new files exist with `rg --files` and file previews via `nl` to confirm content was written as expected (success).
- Ran `git diff --check` to ensure there are no whitespace or diff errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f540ae728833191bbc4bb733cf4a7)